### PR TITLE
Fix Year type

### DIFF
--- a/music/lib.go
+++ b/music/lib.go
@@ -37,7 +37,7 @@ type BTrack struct {
 	ID             string
 	PlayCount      uint32
 	Title          string
-	Year           int
+	Year           uint32
 }
 
 func RefreshLibrary(db *bolt.DB, gm *gmusic.GMusic) error {


### PR DESCRIPTION
Error when i try to build the project:

```
$ make build
[jam] Build 
# github.com/budkin/jam/music
music/lib.go:87: cannot use tracks[i].Year (type uint32) as type int in field value
music/lib.go:128: cannot use tracks[i].Year (type uint32) as type int in field value
make: *** [Makefile:61: build] Error 2
`̀``

Signed-off-by: Nicolas Lamirault <nicolas.lamirault@gmail.com>