### PR TITLE
Fix #31: Disable LastFM scrobbler

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -43,7 +43,7 @@ func loginFromDatabase(db *bolt.DB) (*gmusic.GMusic, error) {
 	}, nil
 }
 
-func CheckCreds(db *bolt.DB) (*gmusic.GMusic, *lastfm.Client, string, error) {
+func CheckCreds(db *bolt.DB, lastFM bool) (*gmusic.GMusic, *lastfm.Client, string, error) {
 	gm, err := loginFromDatabase(db)
 	if err != nil {
 		gm, err = authenticate()
@@ -59,6 +59,9 @@ func CheckCreds(db *bolt.DB) (*gmusic.GMusic, *lastfm.Client, string, error) {
 	}
 	if err != nil {
 		return nil, nil, "", err
+	}
+	if !lastFM {
+		return gm, nil, "", nil
 	}
 
 	lmclient := lastfm.New(

--- a/main.go
+++ b/main.go
@@ -42,14 +42,16 @@ const (
 )
 
 var (
-	vers  bool
-	debug bool
+	vers   bool
+	debug  bool
+	lastFM bool
 )
 
 func init() {
 	// parse flags
 	flag.BoolVar(&vers, "version", false, "print version and exit")
 	flag.BoolVar(&debug, "debug", false, "debug")
+	flag.BoolVar(&lastFM, "lastfm", false, "Enable LastFM scrobbler")
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, fmt.Sprintf(BANNER, version.Version))
@@ -69,7 +71,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Can't open database: %s", err)
 	}
-	gmusic, lmclient, lastfm, err := auth.CheckCreds(db)
+	gmusic, lmclient, lastfm, err := auth.CheckCreds(db, lastFM)
 	if err != nil {
 		log.Fatalf("Can't connect to Google Music: %s", err)
 	}

--- a/ui/linux.go
+++ b/ui/linux.go
@@ -92,7 +92,7 @@ func (app *App) player() {
 			r = &mpa.Reader{Decoder: &mpa.Decoder{Input: song.Body}}
 			defer song.Body.Close()
 			timer := time.Now()
-			if app.Status.LastFM {
+			if app.Status.LastFM && app.LastFM != nil {
 				go app.LastFM.NowPlaying(track.Title, track.Artist)
 			}
 			go func() {
@@ -123,8 +123,9 @@ func (app *App) player() {
 								defDur > 4*time.Minute) && !trackScrobbled &&
 								songDur > 30*time.Second {
 								trackScrobbled = true
-								go app.LastFM.Scrobble(track.Artist, track.Title,
-									timer.Unix())
+								if app.LastFM != nil {
+									go app.LastFM.Scrobble(track.Artist, track.Title, timer.Unix())
+								}
 							}
 							trackScrobbled = false
 							playing = false
@@ -150,8 +151,9 @@ func (app *App) player() {
 								defDur > 4*time.Minute) && !trackScrobbled &&
 								songDur > 30*time.Second {
 								trackScrobbled = true
-								go app.LastFM.Scrobble(track.Artist, track.Title,
-									timer.Unix())
+								if app.LastFM != nil {
+									go app.LastFM.Scrobble(track.Artist, track.Title, timer.Unix())
+								}
 							}
 							switch err.(type) {
 							case mpa.MalformedStream:
@@ -194,7 +196,7 @@ func (app *App) player() {
 							songDur = time.Duration(temp) * time.Millisecond
 							timer = time.Now()
 							trackScrobbled = false
-							if app.Status.LastFM {
+							if app.Status.LastFM && app.LastFM != nil {
 								go app.LastFM.NowPlaying(track.Title, track.Artist)
 							}
 							continue

--- a/ui/windows.go
+++ b/ui/windows.go
@@ -86,7 +86,7 @@ func (app *App) player() {
 			r = &mpa.Reader{Decoder: &mpa.Decoder{Input: song.Body}}
 			defer song.Body.Close()
 			timer := time.Now()
-			if app.Status.LastFM {
+			if app.Status.LastFM && app.LastFM != nil {
 				go app.LastFM.NowPlaying(track.Title, track.Artist)
 			}
 			go func() {
@@ -117,8 +117,9 @@ func (app *App) player() {
 								defDur > 4*time.Minute) && !trackScrobbled &&
 								songDur > 30*time.Second {
 								trackScrobbled = true
-								go app.LastFM.Scrobble(track.Artist, track.Title,
-									timer.Unix())
+								if app.LastFM != nil {
+									go app.LastFM.Scrobble(track.Artist, track.Title, timer.Unix())
+								}
 							}
 							trackScrobbled = false
 							playing = false
@@ -144,8 +145,9 @@ func (app *App) player() {
 								defDur > 4*time.Minute) && !trackScrobbled &&
 								songDur > 30*time.Second {
 								trackScrobbled = true
-								go app.LastFM.Scrobble(track.Artist, track.Title,
-									timer.Unix())
+								if app.LastFM != nil {
+									go app.LastFM.Scrobble(track.Artist, track.Title, timer.Unix())
+								}
 							}
 							switch err.(type) {
 							case mpa.MalformedStream:
@@ -188,7 +190,7 @@ func (app *App) player() {
 							songDur = time.Duration(temp) * time.Millisecond
 							timer = time.Now()
 							trackScrobbled = false
-							if app.Status.LastFM {
+							if app.Status.LastFM && app.LastFM != nil {
 								go app.LastFM.NowPlaying(track.Title, track.Artist)
 							}
 							continue


### PR DESCRIPTION
Add an option to the CLI to enable LastFM scrobbler. Default value is to
not use LastFM.

Signed-off-by: Nicolas Lamirault <nicolas.lamirault@gmail.com>